### PR TITLE
Removing mslib environment dep.

### DIFF
--- a/metriq/client.py
+++ b/metriq/client.py
@@ -1,6 +1,4 @@
-from msilib.schema import Environment
-from urllib import parse
-from typing import Dict, List, Optional
+from typing import List
 
 
 from tea_client.http import HttpClient
@@ -16,11 +14,12 @@ from metriq.models import (
     TaskCreateRequest,
     TaskUpdateRequest,
     Method,
-    Methods,
     MethodCreateRequest,
     MethodUpdateRequest,
     Result,
-    Environment,
+    Platform,
+    PlatformCreateRequest,
+    PlatformUpdateRequest,
 )
 
 
@@ -446,40 +445,40 @@ class MetriqClient:
         ]
 
     @handler
-    def platform_update(self, environment_id: str, environment: EnvironmentUpdateRequest) -> Environment:
-        """Update an Environment.
+    def platform_update(self, platform_id: str, platform: PlatformUpdateRequest) -> Platform:
+        """Update an Platform.
 
         Args:
-            environment_id (str): ID of the environment.
-            environment (environmentUpdateRequest): environment update request.
+            platform_id (str): ID of the platform.
+            platform (platformUpdateRequest): platform update request.
 
         Returns:
-            Environment: Updated environment.
+            Platform: Updated platform.
         """
-        return Environment(**self.http.patch(f"/platform/{environment_id}/", data=environment))
+        return Platform(**self.http.patch(f"/platform/{platform_id}/", data=platform))
 
     @handler
-    def platform_add(self, environment: EnvironmentCreateRequest) -> Environment:
-        """Add an environment.
+    def platform_add(self, platform: PlatformCreateRequest) -> Platform:
+        """Add an platform.
 
         Args:
-            environment (EnvironmentCreateRequest): Environment create request.
+            platform (PlatformCreateRequest): Platform create request.
 
         Returns:
-            Environment: Created environment.
+            Platform: Created platform.
         """
-        response = self.http.post("/platform/", data=environment)
-        return Environment(**response["data"])
+        response = self.http.post("/platform/", data=platform)
+        return Platform(**response["data"])
 
     @handler
-    def platform_get(self) -> List[Environment]:
-        """Return a List of Environment objects.
+    def platform_get(self) -> List[Platform]:
+        """Return a List of Platform objects.
 
         Returns:
-            List: List of Environment objects.
+            List: List of Platform objects.
         """
         response = self.http.get(f"/platform/")
         return [
-            Environment(**r)
+            Platform(**r)
             for r in response["data"]
         ]

--- a/metriq/models/__init__.py
+++ b/metriq/models/__init__.py
@@ -13,9 +13,18 @@ __all__ = [
     "Methods",
     "MethodCreateRequest",
     "MethodUpdateRequest",
+    "Platform",
+    "PlatformCreateRequest",
+    "PlatformUpdateRequest",
     "Result",
     "ModerationReport"
 ]
+
+from metriq.models.platform import (
+    Platform,
+    PlatformCreateRequest,
+    PlatformUpdateRequest,
+)
 
 from metriq.models.submission import (
     Submission,

--- a/metriq/models/platform.py
+++ b/metriq/models/platform.py
@@ -5,16 +5,16 @@ from tea_client.models import TeaClientModel
 from metriq.models.page import Page
 
 
-class Environment(TeaClientModel):
-    """Environment object.
+class Platform(TeaClientModel):
+    """Platform object.
 
     Attributes:
-        id (str): Environment ID.
-        name (str): Environment name.
-        fullName (str): Full name of Environment.
-        description (str): Environment description.
-        submittedDate (str): Date of Environment submission.
-        deletedDate (str): Date of Environment deletion.
+        id (str): Platform ID.
+        name (str): Platform name.
+        fullName (str): Full name of Platform.
+        description (str): Platform description.
+        submittedDate (str): Date of Platform submission.
+        deletedDate (str): Date of Platform deletion.
     """
 
     class Config:
@@ -29,50 +29,50 @@ class Environment(TeaClientModel):
     deletedDate: Optional[str]
 
 
-class EnvironmentCreateRequest(TeaClientModel):
-    """EnvironmentCreateRequest object.
+class PlatformCreateRequest(TeaClientModel):
+    """PlatformCreateRequest object.
 
 
     Attributes:
-        userId (str): The ID of the user submitting the Environment.
-        name (str): Environment name.
-        fullName (str): Full name of Environment.
-        description (str): Environment description.
-        parentEnvironment (str, optional): ID of the parent Environment.
+        userId (str): The ID of the user submitting the Platform.
+        name (str): Platform name.
+        fullName (str): Full name of Platform.
+        description (str): Platform description.
+        parentPlatform (str, optional): ID of the parent Platform.
     """
 
     userId: Optional[str]
     name: Optional[str]
     fullName: Optional[str]
     description: Optional[str] = ""
-    parentEnvironment: Optional[str] = None
+    parentPlatform: Optional[str] = None
 
 
-class EnvironmentUpdateRequest(TeaClientModel):
-    """EnvironmentUpdateRequest object.
+class PlatformUpdateRequest(TeaClientModel):
+    """PlatformUpdateRequest object.
 
     Attributes:
-        userId (str): The ID of the user submitting the Environment.
-        name (str): Environment name.
-        fullName (str): Full name of Environment.
-        description (str): Environment description.
-        parentEnvironment (str, optional): ID of the parent Environment.
+        userId (str): The ID of the user submitting the Platform.
+        name (str): Platform name.
+        fullName (str): Full name of Platform.
+        description (str): Platform description.
+        parentPlatform (str, optional): ID of the parent Platform.
     """
 
     name: Optional[str]
     fullName: Optional[str]
     description: Optional[str] = ""
-    parentEnvironment: Optional[str] = None
+    parentPlatform: Optional[str] = None
 
 
-class Environment(Page):
-    """Object representing a paginated page of Environment.
+class Platform(Page):
+    """Object representing a paginated page of Platform.
 
     Attributes:
         count (int): Number of elements matching the query.
         nextPage (int, optional): Number of the next page.
         previousPage (int, optional): Number of the previous page.
-        results (List[Environment]): List of Environment on this page.
+        results (List[Platform]): List of Platform on this page.
     """
 
-    results: List[Environment]
+    results: List[Platform]


### PR DESCRIPTION
There was an odd dependency from msilib for a variable named `Environment`. I imagine this was mistakenly imported due to some type of IDE helper that imported a dep from the incorrect library and caused a failure. 

Also the term "Environment" was used instead of "Platform" so I made this change as well.  