### PR TITLE
Fixing issue with task API endpoints.

### DIFF
--- a/metriq/models/task.py
+++ b/metriq/models/task.py
@@ -20,7 +20,7 @@ class Task(TeaClientModel):
     class Config:
         fields = {'id': '_id'}
 
-    id: str
+    id: Optional[str]
     userId: Optional[str]
     name: Optional[str]
     fullName: Optional[str]


### PR DESCRIPTION
- The `id` field was not `Optional` which was causing an issue on hitting these endpoints. 