### PR TITLE
Removing result get endpoint.

### DIFF
--- a/examples/result_get.py
+++ b/examples/result_get.py
@@ -1,8 +1,0 @@
-"""Get result from Metriq."""
-import os
-from metriq import MetriqClient
-
-
-client = MetriqClient(token=str(os.environ["METRIQ_CLIENT_API_KEY"]))
-result = client.result_get("6101c6ac1134861ba8fbdd9e")
-assert result is not None

--- a/metriq/client.py
+++ b/metriq/client.py
@@ -510,20 +510,6 @@ class MetriqClient:
         return response["data"]
 
     @handler
-    def result_get(self, result_id: str) -> Method:
-        """Return a result by it's ID.
-
-        Args:
-            result_id (str): ID of the result.
-
-        Returns:
-            Method: Method object.
-        """
-        response = self.http.get(f"/result/{result_id}/")
-        print(response["message"])
-        #return Result(**(self.http.get(f"/result/{result_id}/")['data']))
-
-    @handler
     def result_add(self, result: ResultCreateRequest, submission_id: str) -> Result:
         """Add a result to a submission.
 

--- a/metriq/models/result.py
+++ b/metriq/models/result.py
@@ -1,5 +1,6 @@
 from tea_client.models import TeaClientModel
 from typing import Optional, List
+from metriq.models.page import Page
 
 
 class Result(TeaClientModel):
@@ -35,11 +36,7 @@ class Result(TeaClientModel):
 
 
 class ResultCreateRequest(TeaClientModel):
-    """ResultCreateRequest object.
-
-    Attributes:
-        X
-    """
+    """ResultCreateRequest object."""
     task: Optional[str]
     method: Optional[str]
     platform: Optional[str]
@@ -50,3 +47,8 @@ class ResultCreateRequest(TeaClientModel):
     qubitCount: Optional[str]
     circuitDepth: Optional[str]
     notes: Optional[str]
+
+
+class Results(Page):
+    """Object representing a paginated page of results."""
+    results: List[Result]


### PR DESCRIPTION
Closes #111 

As the `GET` endpoint for the `result/` on `metriq-api` doesn't exist, I've removed this function and example from the client. 

fyi @karlaspuldaro, @WrathfulSpatula 