### PR TITLE
Add a workflow for uploading `metriq-client` to PyPi

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,33 @@
+name: Upload Python Package to PyPi
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install build twine
+
+      - name: Build package
+        run: python -m build
+
+      - name: Publish to PyPi
+        env:
+          TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
+          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+        run: twine upload dist/*


### PR DESCRIPTION
Summary:

Uploads this client to PyPi on tagged release in the form `v*`. Like `v0.0.0`.

To do:

- [ ] set `TWINE_USERNAME` to GitHub Actions Environment secrets
- [ ] set `TWINE_PASSWORD` to GitHub Actions Environment secrets
